### PR TITLE
Fix a flaky test, caused by the indeterministic order of File.listFiles()

### DIFF
--- a/src/test/java/de/heinrichmarkus/gradle/delphi/utils/zip/ZipAdapterTest.java
+++ b/src/test/java/de/heinrichmarkus/gradle/delphi/utils/zip/ZipAdapterTest.java
@@ -51,6 +51,8 @@ public class ZipAdapterTest {
         List<AssemblyItem> list = new ArrayList<>();
         list.add(item);
         List<ZipFileMapping> mappings = ZipAdapter.toMapping(list);
+        // sort the list, because the order of the files is not guaranteed
+        mappings.sort((o1, o2) -> o1.getDestFileName().compareTo(o2.getDestFileName()));
         assertEquals(destFileNames.length, mappings.size());
         for (int i = 0; i < destFileNames.length; i++) {
             String expected = destFileNames[i].replace("/", File.separator);


### PR DESCRIPTION
### Description

- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [X] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation

Fix a flaky test, caused by the indeterministic order of File.listFiles()

### Related Test
[de.heinrichmarkus.gradle.delphi.utils.zip.ZipAdapterTest.toMappingSimpleDir](https://github.com/lxb007981/delphi-build-plugin/blob/39170f16e0ef0b8d5409c034b0278952f8adc351/src/test/java/de/heinrichmarkus/gradle/delphi/utils/zip/ZipAdapterTest.java#L38)
and
[de.heinrichmarkus.gradle.delphi.utils.zip.ZipAdapterTest.toMappingSimpleDirToSubdir](https://github.com/lxb007981/delphi-build-plugin/blob/39170f16e0ef0b8d5409c034b0278952f8adc351/src/test/java/de/heinrichmarkus/gradle/delphi/utils/zip/ZipAdapterTest.java#L44C41-L44C41)

### Root Cause
https://github.com/lxb007981/delphi-build-plugin/blob/39170f16e0ef0b8d5409c034b0278952f8adc351/src/test/java/de/heinrichmarkus/gradle/delphi/utils/zip/ZipAdapterTest.java#L50-L58

https://github.com/lxb007981/delphi-build-plugin/blob/39170f16e0ef0b8d5409c034b0278952f8adc351/src/main/java/de/heinrichmarkus/gradle/delphi/utils/zip/ZipAdapter.java#L58-L60

When getting the pathnames in a directory, the method `File.listFiles()` does not guarantee the name strings in the resulting array will appear in any specific order. In the two related tests, this nondeterministic list of pathnames are compared to a fixed list of pathnames, which leads to the flakiness.

### Fix
We sort the pathnames list before comparing it with the fixed-list.

### How to reproduce the test
**Java version**: 11.0.20.1
**Gradle version**: 5.4.1

1. Build the module
`gradle build`
2. Test without shuffling
`gradle --info test --tests de.heinrichmarkus.gradle.delphi.utils.zip.ZipAdapterTest.toMappingSimpleDir`
`gradle --info test --tests de.heinrichmarkus.gradle.delphi.utils.zip.ZipAdapterTest.toMappingSimpleDirToSubdir`
These two tests passed.

3. Test with shuffling using [NonDex](https://github.com/TestingResearchIllinois/NonDex)
`gradle --info nondexTest --tests de.heinrichmarkus.gradle.delphi.utils.zip.ZipAdapterTest.toMappingSimpleDir`
`gradle --info nondexTest --tests de.heinrichmarkus.gradle.delphi.utils.zip.ZipAdapterTest.toMappingSimpleDirToSubdir`
The tests passed with the proposed fix but failed without it.